### PR TITLE
Adds Media Server ID option to scan verb.

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,8 @@ For TURNS, certificate expiry can also be tested. If a certificate is expiring w
 
   --tag                   The client's tag.
 
+  --media-server-id       The Media Server to test.
+
   -g, --gateway-url       (Default: http://localhost:8080/sync) The Gateway URL.
 
   -a, --application-id    (Default: my-app-id) The application identifier.

--- a/src/FM.LiveSwitch.Hammer/ScanTest.cs
+++ b/src/FM.LiveSwitch.Hammer/ScanTest.cs
@@ -159,7 +159,8 @@ namespace FM.LiveSwitch.Hammer
         private async Task<MediaServerInfo[]> GetMediaServers()
         {
             var responseJson = await _HttpClient.GetStringAsync("v1/mediaservers").ConfigureAwait(false);
-            return JsonConvert.DeserializeObject<MediaServerInfo[]>(responseJson);
+            var mediaServers = JsonConvert.DeserializeObject<MediaServerInfo[]>(responseJson);
+            return mediaServers.Where(mediaServer => Options.ShouldTest(mediaServer.Id)).ToArray();
         }
 
         private async Task<MediaServerInfo> GetMediaServer(string mediaServerId)

--- a/src/FM.LiveSwitch.Hammer/ScanTestMediaServer.cs
+++ b/src/FM.LiveSwitch.Hammer/ScanTestMediaServer.cs
@@ -194,13 +194,13 @@ namespace FM.LiveSwitch.Hammer
 
         #region Open and Close Connections
 
-        private McuConnection _Connection;
+        private SfuConnection _Connection;
 
         private async Task OpenConnection(string mediaServerId, ScanTestScenario scenario, CancellationToken cancellationToken)
         {
             Console.Error.WriteLine($"Opening connection ({scenario.ToDisplayString()})...");
 
-            _Connection = _Channel.CreateMcuConnection(new AudioStream(new AudioTrack(new NullAudioSource(new Opus.Format { IsPacketized = true }))));
+            _Connection = _Channel.CreateSfuUpstreamConnection(new AudioStream(new AudioTrack(new NullAudioSource(new Opus.Format { IsPacketized = true }))));
 
             _Connection.PreferredMediaServerId = mediaServerId;
 

--- a/src/FM.LiveSwitch.Hammer/ScanTestOptions.cs
+++ b/src/FM.LiveSwitch.Hammer/ScanTestOptions.cs
@@ -41,6 +41,18 @@ namespace FM.LiveSwitch.Hammer
         [Option("tag", Default = null, HelpText = "The client's tag.")]
         public string Tag { get; set; }
 
+        [Option("media-server-id", Default = null, HelpText = "The Media Server to test.")]
+        public string MediaServerId { get; set; }
+
+        public bool ShouldTest(string mediaServerId)
+        {
+            if (!string.IsNullOrEmpty(MediaServerId))
+            {
+                return MediaServerId == mediaServerId;
+            }
+            return true;
+        }
+
         public bool ShouldTest(ScanTestScenario scenario)
         {
             if ((NoHost && scenario == ScanTestScenario.Host) ||


### PR DESCRIPTION
- Adds `media-server-id` option to the `scan` verb to allow targeting a specific Media Server instead of the entire cluster.