### PR TITLE
Eliminating a false positive

### DIFF
--- a/src/FM.LiveSwitch.Hammer/CapacityThresholds.cs
+++ b/src/FM.LiveSwitch.Hammer/CapacityThresholds.cs
@@ -1,0 +1,19 @@
+﻿namespace FM.LiveSwitch.Hammer
+{
+    class CapacityThresholds
+    {
+        public bool Enabled { get; set; }
+
+        public int? McuConnectionsPerCpuThreshold { get; set; }
+
+        public int? SfuConnectionsPerCpuThreshold { get; set; }
+
+        public int? SafeMcuConnectionsPerCpuThreshold { get; set; }
+
+        public int? SafeSfuConnectionsPerCpuThreshold { get; set; }
+
+        public int? UnsafeMcuConnectionsPerCpuThreshold { get; set; }
+
+        public int? UnsafeSfuConnectionsPerCpuThreshold { get; set; }
+    }
+}

--- a/src/FM.LiveSwitch.Hammer/DeploymentConfig.cs
+++ b/src/FM.LiveSwitch.Hammer/DeploymentConfig.cs
@@ -1,0 +1,7 @@
+﻿namespace FM.LiveSwitch.Hammer
+{
+    class DeploymentConfig
+    {
+        public CapacityThresholds CapacityThresholds { get; set; }
+    }
+}

--- a/src/FM.LiveSwitch.Hammer/MediaServerInfo.cs
+++ b/src/FM.LiveSwitch.Hammer/MediaServerInfo.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace FM.LiveSwitch.Hammer
+﻿namespace FM.LiveSwitch.Hammer
 {
     class MediaServerInfo
     {
@@ -17,5 +13,9 @@ namespace FM.LiveSwitch.Hammer
         public double UsedCapacity { get; set; }
 
         public bool Draining { get; set; }
+
+        public int CoreCount { get; set; }
+
+        public string DeploymentId { get; set; }
     }
 }


### PR DESCRIPTION
- Added a check for `MediaServerMismatchException` to see if the connection was redirected because the Media Server would have been made over-capacity.