### PR TITLE
Improved Scan output

### DIFF
--- a/src/FM.LiveSwitch.Hammer/MediaServerInfo.cs
+++ b/src/FM.LiveSwitch.Hammer/MediaServerInfo.cs
@@ -1,8 +1,12 @@
-﻿namespace FM.LiveSwitch.Hammer
+﻿using Newtonsoft.Json;
+
+namespace FM.LiveSwitch.Hammer
 {
     class MediaServerInfo
     {
         public string Id { get; set; }
+
+        public string Region { get; set; }
 
         public bool Available { get; set; }
 
@@ -14,8 +18,15 @@
 
         public bool Draining { get; set; }
 
+        public string[] IPAddresses { get; set; }
+
+        public string PublicIPAddress { get; set; }
+
+        public string Version { get; set; }
+
         public int CoreCount { get; set; }
 
+        [JsonIgnore]
         public string DeploymentId { get; set; }
     }
 }

--- a/src/FM.LiveSwitch.Hammer/ScanTest.cs
+++ b/src/FM.LiveSwitch.Hammer/ScanTest.cs
@@ -84,21 +84,21 @@ namespace FM.LiveSwitch.Hammer
                 if (!mediaServer.Active)
                 {
                     Console.Error.WriteLine("Media Server is inactive. Skipping...");
-                    return ScanTestMediaServerResult.Skip(mediaServer.Id, "Media Server is inactive.");
+                    return ScanTestMediaServerResult.Skip(mediaServer, "Media Server is inactive.");
                 }
 
                 // don't test draining Media Servers
                 if (mediaServer.Draining)
                 {
                     Console.Error.WriteLine("Media Server is draining. Skipping...");
-                    return ScanTestMediaServerResult.Skip(mediaServer.Id, "Media Server is draining.");
+                    return ScanTestMediaServerResult.Skip(mediaServer, "Media Server is draining.");
                 }
 
                 // don't test over-capacity Media Servers
                 if (mediaServer.OverCapacity)
                 {
                     Console.Error.WriteLine("Media Server is over-capacity. Skipping...");
-                    return ScanTestMediaServerResult.Skip(mediaServer.Id, "Media Server is over-capacity.");
+                    return ScanTestMediaServerResult.Skip(mediaServer, "Media Server is over-capacity.");
                 }
 
                 // scan Media Server
@@ -116,12 +116,12 @@ namespace FM.LiveSwitch.Hammer
                     if (await MediaServerIsGone(mediaServer.Id).ConfigureAwait(false))
                     {
                         Console.Error.WriteLine("Media Server has unregistered. Skipping...");
-                        return ScanTestMediaServerResult.Skip(mediaServer.Id, "Media Server has unregistered.");
+                        return ScanTestMediaServerResult.Skip(mediaServer, "Media Server has unregistered.");
                     }
                     else if (await MediaServerWouldBeOverCapacity(mediaServer.Id).ConfigureAwait(false))
                     {
                         Console.Error.WriteLine("Media Server would be over-capacity. Skipping...");
-                        return ScanTestMediaServerResult.Skip(mediaServer.Id, "Media Server would be over-capacity.");
+                        return ScanTestMediaServerResult.Skip(mediaServer, "Media Server would be over-capacity.");
                     }
                 }
 
@@ -140,11 +140,11 @@ namespace FM.LiveSwitch.Hammer
         {
             try
             {
-                return new ScanTestMediaServer(Options).Run(mediaServer.Id, cancellationToken);
+                return new ScanTestMediaServer(Options).Run(mediaServer, cancellationToken);
             }
             catch (Exception ex)
             {
-                return Task.FromResult(ScanTestMediaServerResult.Fail(mediaServer.Id, ex));
+                return Task.FromResult(ScanTestMediaServerResult.Fail(mediaServer, ex));
             }
         }
 

--- a/src/FM.LiveSwitch.Hammer/ScanTestMediaServer.cs
+++ b/src/FM.LiveSwitch.Hammer/ScanTestMediaServer.cs
@@ -18,9 +18,9 @@ namespace FM.LiveSwitch.Hammer
             ServerCertificates = new ConcurrentDictionary<string, X509Certificate2>();
         }
 
-        public async Task<ScanTestMediaServerResult> Run(string mediaServerId, CancellationToken cancellationToken)
+        public async Task<ScanTestMediaServerResult> Run(MediaServerInfo mediaServer, CancellationToken cancellationToken)
         {
-            var result = ScanTestMediaServerResult.Pass(mediaServerId);
+            var result = ScanTestMediaServerResult.Pass(mediaServer);
             try
             {
                 await RegisterClient(cancellationToken).ConfigureAwait(false);
@@ -73,7 +73,7 @@ namespace FM.LiveSwitch.Hammer
                                 }
                                 try
                                 {
-                                    await OpenConnection(mediaServerId, scenario, cancellationToken).ConfigureAwait(false);
+                                    await OpenConnection(mediaServer.Id, scenario, cancellationToken).ConfigureAwait(false);
 
                                     // pass
                                     result.SetScenarioResult(scenario, ScanTestScenarioResult.Pass(scenario, certificateValidFor));

--- a/src/FM.LiveSwitch.Hammer/ScanTestMediaServerResult.cs
+++ b/src/FM.LiveSwitch.Hammer/ScanTestMediaServerResult.cs
@@ -7,7 +7,7 @@ namespace FM.LiveSwitch.Hammer
 {
     class ScanTestMediaServerResult : ScanTestResult
     {
-        public string MediaServerId { get; private set; }
+        public MediaServerInfo MediaServer { get; private set; }
 
         public ScanTestScenarioResult[] Results { get { return _ScenarioResults.Select(x => x.Value).ToArray();  } }
 
@@ -25,41 +25,41 @@ namespace FM.LiveSwitch.Hammer
 
         private readonly Dictionary<ScanTestScenario, ScanTestScenarioResult> _ScenarioResults;
 
-        private ScanTestMediaServerResult(string mediaServerId)
+        private ScanTestMediaServerResult(MediaServerInfo mediaServer)
         {
-            MediaServerId = mediaServerId;
+            MediaServer = mediaServer;
 
             _ScenarioResults = new Dictionary<ScanTestScenario, ScanTestScenarioResult>();
         }
 
-        public static ScanTestMediaServerResult Unknown(string mediaServerId)
+        public static ScanTestMediaServerResult Unknown(MediaServerInfo mediaServer)
         {
-            return new ScanTestMediaServerResult(mediaServerId)
+            return new ScanTestMediaServerResult(mediaServer)
             {
                 State = ScanTestState.Unknown
             };
         }
 
-        public static ScanTestMediaServerResult Pass(string mediaServerId)
+        public static ScanTestMediaServerResult Pass(MediaServerInfo mediaServer)
         {
-            return new ScanTestMediaServerResult(mediaServerId)
+            return new ScanTestMediaServerResult(mediaServer)
             {
                 State = ScanTestState.Pass
             };
         }
 
-        public static ScanTestMediaServerResult Fail(string mediaServerId, Exception exception)
+        public static ScanTestMediaServerResult Fail(MediaServerInfo mediaServer, Exception exception)
         {
-            return new ScanTestMediaServerResult(mediaServerId)
+            return new ScanTestMediaServerResult(mediaServer)
             {
                 State = ScanTestState.Fail,
                 Exception = exception
             };
         }
 
-        public static ScanTestMediaServerResult Skip(string mediaServerId, string reason)
+        public static ScanTestMediaServerResult Skip(MediaServerInfo mediaServer, string reason)
         {
-            return new ScanTestMediaServerResult(mediaServerId)
+            return new ScanTestMediaServerResult(mediaServer)
             {
                 State = ScanTestState.Skip,
                 Reason = reason

--- a/src/FM.LiveSwitch.Hammer/ScanTestMediaServerResult.cs
+++ b/src/FM.LiveSwitch.Hammer/ScanTestMediaServerResult.cs
@@ -5,29 +5,23 @@ using System.Linq;
 
 namespace FM.LiveSwitch.Hammer
 {
-    class ScanTestMediaServerResult
+    class ScanTestMediaServerResult : ScanTestResult
     {
         public string MediaServerId { get; private set; }
 
-        public ScanTestState State { get; private set; }
-
-        public Exception Exception { get; private set; }
-
-        public string Reason { get; private set; }
-
-        public ScanTestScenarioResult[] ScenarioResults { get { return _ScenarioResults.Select(x => x.Value).ToArray();  } }
+        public ScanTestScenarioResult[] Results { get { return _ScenarioResults.Select(x => x.Value).ToArray();  } }
 
         [JsonIgnore]
-        public ScanTestScenarioResult[] PassedScenarioResults { get { return _ScenarioResults.Where(x => x.Value.State == ScanTestState.Pass).Select(x => x.Value).ToArray(); } }
+        public ScanTestScenarioResult[] PassedResults { get { return _ScenarioResults.Where(x => x.Value.State == ScanTestState.Pass).Select(x => x.Value).ToArray(); } }
 
         [JsonIgnore]
-        public ScanTestScenarioResult[] FailedScenarioResults { get { return _ScenarioResults.Where(x => x.Value.State == ScanTestState.Fail).Select(x => x.Value).ToArray(); } }
+        public ScanTestScenarioResult[] FailedResults { get { return _ScenarioResults.Where(x => x.Value.State == ScanTestState.Fail).Select(x => x.Value).ToArray(); } }
 
         [JsonIgnore]
-        public ScanTestScenarioResult[] SkippedScenarioResults { get { return _ScenarioResults.Where(x => x.Value.State == ScanTestState.Skip).Select(x => x.Value).ToArray(); } }
+        public ScanTestScenarioResult[] SkippedResults { get { return _ScenarioResults.Where(x => x.Value.State == ScanTestState.Skip).Select(x => x.Value).ToArray(); } }
 
         [JsonIgnore]
-        public ScanTestScenarioResult[] UnknownScenarioResults { get { return _ScenarioResults.Where(x => x.Value.State == ScanTestState.Unknown).Select(x => x.Value).ToArray(); } }
+        public ScanTestScenarioResult[] UnknownResults { get { return _ScenarioResults.Where(x => x.Value.State == ScanTestState.Unknown).Select(x => x.Value).ToArray(); } }
 
         private readonly Dictionary<ScanTestScenario, ScanTestScenarioResult> _ScenarioResults;
 
@@ -59,7 +53,6 @@ namespace FM.LiveSwitch.Hammer
             return new ScanTestMediaServerResult(mediaServerId)
             {
                 State = ScanTestState.Fail,
-                Reason = exception.Message,
                 Exception = exception
             };
         }
@@ -84,14 +77,13 @@ namespace FM.LiveSwitch.Hammer
 
         public void SetScenarioResult(ScanTestScenario scenario, ScanTestScenarioResult scenarioResult)
         {
+            _ScenarioResults[scenario] = scenarioResult;
+
             if (scenarioResult.State == ScanTestState.Fail)
             {
                 State = ScanTestState.Fail;
-                Exception = scenarioResult.Exception;
-                Reason = Exception.Message;
+                Reason = $"{FailedResults.Length} scenario(s) failed.";
             }
-
-            _ScenarioResults[scenario] = scenarioResult;
         }
 
         public bool IsCertificateExpiring(TimeSpan maxCertificateValidFor)

--- a/src/FM.LiveSwitch.Hammer/ScanTestResult.cs
+++ b/src/FM.LiveSwitch.Hammer/ScanTestResult.cs
@@ -1,0 +1,46 @@
+﻿using Newtonsoft.Json;
+using System;
+
+namespace FM.LiveSwitch.Hammer
+{
+    class ScanTestResult
+    {
+        public ScanTestState State { get; protected set; }
+
+        [JsonIgnore]
+        public Exception Exception
+        {
+            get { return _Exception; }
+            protected set 
+            {
+                _Exception = value;
+
+                Reason = ExceptionToReason(value);
+            }
+        }
+        private Exception _Exception;
+
+        public string Reason { get; protected set; }
+
+        private string ExceptionToReason(Exception exception)
+        {
+            if (exception == null)
+            {
+                return null;
+            }
+
+            if (exception is AggregateException aggregateException)
+            {
+                return ExceptionToReason(aggregateException.InnerException);
+            }
+
+            var innerException = exception.InnerException;
+            if (innerException == null)
+            {
+                return exception.Message;
+            }
+
+            return $"{exception.Message} [{ExceptionToReason(exception.InnerException)}]";
+        }
+    }
+}

--- a/src/FM.LiveSwitch.Hammer/ScanTestScenarioResult.cs
+++ b/src/FM.LiveSwitch.Hammer/ScanTestScenarioResult.cs
@@ -3,11 +3,9 @@ using System;
 
 namespace FM.LiveSwitch.Hammer
 {
-    class ScanTestScenarioResult
+    class ScanTestScenarioResult : ScanTestResult
     {
         public ScanTestScenario Scenario { get; private set; }
-
-        public ScanTestState State { get; private set; }
 
         [JsonIgnore]
         public TimeSpan? CertificateValidFor { get; private set; }
@@ -24,10 +22,6 @@ namespace FM.LiveSwitch.Hammer
                 return (int)Math.Max(0, certificateValidFor.Value.TotalDays);
             }
         }
-
-        public Exception Exception { get; private set; }
-
-        public string Reason { get; private set; }
 
         private ScanTestScenarioResult() { }
 
@@ -56,7 +50,6 @@ namespace FM.LiveSwitch.Hammer
             {
                 Scenario = scenario,
                 State = ScanTestState.Fail,
-                Reason = exception.Message,
                 Exception = exception
             };
         }


### PR DESCRIPTION
- Improved the JSON output (failed tests) of the `scan` verb by eliminating exception serialization, copying the important bits into the serialized reason output, including detail about the specific scenarios that failed, and including more information about the Media Server that failed one or more scenarios.