### PR TITLE
Added the "--sdk-log-level" option to enable/configure LiveSwitch SDK logging.

### DIFF
--- a/src/FM.LiveSwitch.Hammer/ClusterTest.cs
+++ b/src/FM.LiveSwitch.Hammer/ClusterTest.cs
@@ -4,11 +4,12 @@ using System.Threading.Tasks;
 
 namespace FM.LiveSwitch.Hammer
 {
-    class ClusterTest
+    class ClusterTest : Test
     {
         public ClusterTestOptions Options { get; private set; }
 
         public ClusterTest(ClusterTestOptions options)
+            : base(options)
         {
             Options = options;
         }

--- a/src/FM.LiveSwitch.Hammer/LoadTest.cs
+++ b/src/FM.LiveSwitch.Hammer/LoadTest.cs
@@ -4,11 +4,12 @@ using System.Threading.Tasks;
 
 namespace FM.LiveSwitch.Hammer
 {
-    class LoadTest
+    class LoadTest : Test
     {
         public LoadTestOptions Options { get; private set; }
 
         public LoadTest(LoadTestOptions options)
+            : base(options)
         {
             Options = options;
         }

--- a/src/FM.LiveSwitch.Hammer/Options.cs
+++ b/src/FM.LiveSwitch.Hammer/Options.cs
@@ -12,5 +12,8 @@ namespace FM.LiveSwitch.Hammer
 
         [Option('s', "shared-secret", Default = "--replaceThisWithYourOwnSharedSecret--", HelpText = "The shared secret.")]
         public string SharedSecret { get; set; }
+
+        [Option("sdk-log-level", Default = LogLevel.None, HelpText = "The LiveSwitch SDK log level.")]
+        public LogLevel SdkLogLevel { get; set; }
     }
 }

--- a/src/FM.LiveSwitch.Hammer/ScanTest.cs
+++ b/src/FM.LiveSwitch.Hammer/ScanTest.cs
@@ -8,13 +8,14 @@ using System.Threading.Tasks;
 
 namespace FM.LiveSwitch.Hammer
 {
-    class ScanTest
+    class ScanTest : Test
     {
         public ScanTestOptions Options { get; private set; }
 
         private HttpClient _HttpClient;
 
         public ScanTest(ScanTestOptions options)
+            : base(options)
         {
             Options = options;
 

--- a/src/FM.LiveSwitch.Hammer/SdkLogProvider.cs
+++ b/src/FM.LiveSwitch.Hammer/SdkLogProvider.cs
@@ -1,0 +1,17 @@
+﻿using System;
+
+namespace FM.LiveSwitch.Hammer
+{
+    class SdkLogProvider : LogProvider
+    {
+        public SdkLogProvider(LogLevel level)
+        {
+            Level = level;
+        }
+
+        protected override void DoLog(LogEvent logEvent)
+        {
+            Console.Error.WriteLine(GenerateLogLine(logEvent));
+        }
+    }
+}

--- a/src/FM.LiveSwitch.Hammer/Test.cs
+++ b/src/FM.LiveSwitch.Hammer/Test.cs
@@ -1,0 +1,13 @@
+﻿namespace FM.LiveSwitch.Hammer
+{
+    abstract class Test
+    {
+        protected Test(Options options)
+        {
+            if (options.SdkLogLevel != LogLevel.None)
+            {
+                Log.Provider = new SdkLogProvider(options.SdkLogLevel);
+            }
+        }
+    }
+}


### PR DESCRIPTION
The default option is "None" which matches the current implementation where no SDK logging is output.