### PR TITLE
retry on non success http code for mediaservers endpoint

### DIFF
--- a/src/FM.LiveSwitch.Hammer/Program.cs
+++ b/src/FM.LiveSwitch.Hammer/Program.cs
@@ -118,6 +118,11 @@ namespace FM.LiveSwitch.Hammer
                 LogException(ex);
                 return 6;
             }
+            catch(System.Net.Http.HttpRequestException ex)
+            {
+                LogException(ex);
+                return 7;
+            }
         }
 
         private static void LogException(Exception ex)

--- a/src/FM.LiveSwitch.Hammer/Program.cs
+++ b/src/FM.LiveSwitch.Hammer/Program.cs
@@ -118,7 +118,7 @@ namespace FM.LiveSwitch.Hammer
                 LogException(ex);
                 return 6;
             }
-            catch(System.Net.Http.HttpRequestException ex)
+            catch (System.Net.Http.HttpRequestException ex)
             {
                 LogException(ex);
                 return 7;

--- a/src/FM.LiveSwitch.Hammer/ScanTest.cs
+++ b/src/FM.LiveSwitch.Hammer/ScanTest.cs
@@ -200,8 +200,8 @@ namespace FM.LiveSwitch.Hammer
             }
 
             var sfuConnectionsPerCpuThreshold =
-                capacityThresholds.SfuConnectionsPerCpuThreshold ?? 
-                capacityThresholds.SafeSfuConnectionsPerCpuThreshold ?? 
+                capacityThresholds.SfuConnectionsPerCpuThreshold ??
+                capacityThresholds.SafeSfuConnectionsPerCpuThreshold ??
                 capacityThresholds.UnsafeSfuConnectionsPerCpuThreshold;
             if (sfuConnectionsPerCpuThreshold == null || sfuConnectionsPerCpuThreshold <= 0)
             {
@@ -223,32 +223,31 @@ namespace FM.LiveSwitch.Hammer
 
             var count = 0;
             var delay = 100;
-            while(true)//we either break out of the loop, or throw an exception
+            while (true)//we either break out of the loop, or throw an exception
             {
                 try
                 {
                     responseJson = await _HttpClient.GetStringAsync("v1/mediaservers").ConfigureAwait(false);
                     break;
                 }
-                catch(System.Net.Http.HttpRequestException ex)
+                catch (System.Net.Http.HttpRequestException ex)
                 {
-                    if(count <= 5)
+                    if (count <= 5)
                     {
-                        Log.Warn("Unable to retrieve media servers; retrying...", ex);
+                        Log.Warn($"Unable to retrieve Media Servers; retrying after {delay} milliseconds...", ex);
                         await Task.Delay(delay).ConfigureAwait(false);
 
                         count++;
                         delay *= 2;
-                        
                     }
                     else
                     {
-                        Log.Error("Unable to retrieve media servers; retry count exceeded.", ex);
+                        Log.Error("Unable to retrieve Media Servers; retry count exceeded.", ex);
                         throw;
                     }
-                }    
+                }
             }
-            
+
             var mediaServers = JsonConvert.DeserializeObject<MediaServerInfo[]>(responseJson);
             return mediaServers.Where(mediaServer => Options.ShouldTest(mediaServer.Id)).ToArray();
         }


### PR DESCRIPTION
Description
Hammer runs against public cloud on a schedule. It gets a list of all available media servers and does an automated connection test across all supported protocols for all media servers.

However, issues retrieving available mediaservers can cause unhandled exceptions, which in turn pings the DRI team and #cloud-alert-p1 over SMS.

The issues appear to be ephemeral as subsequent runs of the hammer tool work as expected.

Instead of failing, hammer should log the issue and retry.

Steps to Test

Run a GW locally and alter the v1/mediaservers call to return a non success http status code (e.g. 503).

Run hammer locally using the scan verb.
e.g.
`lshammer scan --gateway-url url --application-id my-app-id --shared-secret secret --api-key my-api-key --api-base-url apiurl --min-cert-days 14`

Ensure that when a call to v1/mediaservers fails with an http status code, the call should be retried. If all subsequent attempts fail, hammer should fail gracefully and indicate non success. No unhandled exceptions should be thrown

Ensure scans when v1/mediaservers is available are unaffected.